### PR TITLE
Feature/48 globの最終調整とテストケース搭載

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,301 +6,151 @@
 /*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/12 17:11:46 by nnishiya          #+#    #+#             */
-/*   Updated: 2025/09/29 16:31:43 by tkuwahat         ###   ########.fr       */
+/*   Updated: 2025/09/29 19:30:42 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
 
-/* ===== readline スタブ =====
-   ライブラリより前にこのオブジェクトをリンクして、確実にこちらを使わせる */
-static const char **g_lines = NULL;
-static size_t g_nlines = 0;
-static size_t g_idx = 0;
-
-char *readline(const char *prompt)
+/* ---- テスト用ファイル/ディレクトリ作成 ---- */
+static void touch(const char *path)
 {
-	size_t len;
-	char *s;
-
-	(void)prompt;
-	if (g_lines == NULL)
-		return NULL;
-	if (g_idx >= g_nlines)
-		return NULL;
-	len = strlen(g_lines[g_idx]);
-	s = (char *)malloc(len + 1);
-	if (s == NULL)
-		return NULL;
-	memcpy(s, g_lines[g_idx], len + 1);
-	g_idx++;
-	return s;
+	int fd = open(path, O_CREAT | O_WRONLY, 0644);
+	if (fd >= 0)
+		close(fd);
 }
 
-/* ===== 最小限のトークン生成 ===== */
-static t_arg_part *new_part(const char *text, t_quote_type q)
+static int setup_fs(void)
 {
-	t_arg_part *p;
+	if (mkdir("_globtest", 0755) < 0 && access("_globtest", F_OK) != 0)
+		return -1;
 
-	p = (t_arg_part *)calloc(1, sizeof(*p));
-	if (p == NULL)
-		return NULL;
-	if (text != NULL)
-		p->text = strdup(text);
-	else
-		p->text = strdup("");
-	if (p->text == NULL)
+	touch("_globtest/a.c");
+	touch("_globtest/ab.c");
+	touch("_globtest/aaa.txt");
+	touch("_globtest/abc.txt");
+	touch("_globtest/b.txt");
+	touch("_globtest/note.md");
+	touch("_globtest/Makefile");
+	(void)mkdir("_globtest/dir", 0755);
+	touch("_globtest/dir/x.c");
+	return 0;
+}
+
+
+static void print_argv(const t_cmd *c)
+{
+	size_t i = 0;
+	printf("argc=%zu\n", c->argc);
+	while (i < (size_t)c->argc && c->argv && c->argv[i])
 	{
-		free(p);
-		return NULL;
-	}
-	p->quote = q;
-	p->has_param = 0;
-	p->has_unq_glob = 0;
-	p->next = NULL;
-	return p;
-}
-
-static t_token *new_arg_token_one_part(const char *word, t_quote_type q)
-{
-	t_token *t;
-
-	t = (t_token *)calloc(1, sizeof(*t));
-	if (t == NULL)
-		return NULL;
-	t->type = TOK_ARG;
-	if (word != NULL)
-		t->u.arg.raw = strdup(word);
-	else
-		t->u.arg.raw = strdup("");
-	if (t->u.arg.raw == NULL)
-	{
-		free(t);
-		return NULL;
-	}
-	t->u.arg.parts = new_part(word, q);
-	if (t->u.arg.parts == NULL)
-	{
-		free(t->u.arg.raw);
-		free(t);
-		return NULL;
-	}
-	t->u.arg.items = NULL;
-	t->u.arg.n_items = 0;
-	t->u.arg.expanded = 0;
-	t->next = NULL;
-	return t;
-}
-
-static void free_arg_token(t_token *t)
-{
-	size_t i;
-
-	if (t == NULL)
-		return;
-	if (t->type == TOK_ARG)
-	{
-		free_parts(t->u.arg.parts); /* プロジェクト側の実装 */
-		if (t->u.arg.items != NULL)
-		{
-			i = 0;
-			while (t->u.arg.items[i] != NULL)
-			{
-				free(t->u.arg.items[i]);
-				i++;
-			}
-			free(t->u.arg.items);
-		}
-		free(t->u.arg.raw);
-	}
-	free(t);
-}
-
-/* ===== redir / cmd 構築 ===== */
-static void redir_make_heredoc(t_redir *r, t_token *delim_tok, t_quote_type q)
-{
-	r->fd = -1;
-	r->kind = TOK_HEREDOC;
-	r->word = delim_tok;
-	if (q == Q_NONE)
-		r->quoted_heredoc = 0;
-	else
-		r->quoted_heredoc = 1;
-	r->path = NULL;
-}
-
-static void cmd_init_1_heredoc(t_cmd *c, t_token *delim_tok, t_quote_type q)
-{
-	c->redirs = (t_redir *)calloc(1, sizeof(t_redir));
-	c->n_redirs = 1;
-	redir_make_heredoc(&c->redirs[0], delim_tok, q);
-	c->argv_tokens = NULL;
-	c->n_argv_tokens = 0;
-	c->argv = NULL;
-	c->argc = 0;
-}
-
-static void cmd_destroy(t_cmd *c)
-{
-	size_t i;
-	size_t k;
-
-	if (c == NULL)
-		return;
-	i = 0;
-	while (i < c->n_redirs)
-	{
-		if (c->redirs[i].fd >= 0)
-			close(c->redirs[i].fd);
-		free_arg_token(c->redirs[i].word);
-		free(c->redirs[i].path);
+		printf("argv[%zu]=\"%s\"\n", i, c->argv[i]);
 		i++;
 	}
-	free(c->redirs);
-	if (c->argv != NULL)
-	{
-		k = 0;
-		while (c->argv[k] != NULL)
-		{
-			free(c->argv[k]);
-			k++;
-		}
-		free(c->argv);
-	}
 }
 
-/* ===== fd 全読み（パイプ/ファイル両対応） ===== */
-static char *read_all_from_fd(int fd)
+static char **dup_argv_heap(const char *const *src, int argc)
 {
-	size_t cap;
-	size_t len;
-	char *buf;
-	size_t ncap;
-	char *nb;
-	ssize_t n;
-
-	cap = 1024;
-	len = 0;
-	buf = (char *)malloc(cap);
-	if (buf == NULL)
+	int i = 0;
+	char **v = (char **)malloc(sizeof(char *) * (argc + 1));
+	if (!v)
 		return NULL;
-	for (;;)
+	while (i < argc)
 	{
-		if (len + 512 > cap)
+		size_t len = strlen(src[i]);
+		v[i] = (char *)malloc(len + 1);
+		if (!v[i])
 		{
-			ncap = cap * 2;
-			nb = (char *)realloc(buf, ncap);
-			if (nb == NULL)
+			int k = 0;
+			while (k < i)
 			{
-				free(buf);
-				return NULL;
+				free(v[k]);
+				k++;
 			}
-			buf = nb;
-			cap = ncap;
-		}
-		n = read(fd, buf + len, 512);
-		if (n < 0)
-		{
-			free(buf);
+			free(v);
 			return NULL;
 		}
-		if (n == 0)
-			break;
-		len += (size_t)n;
+		memcpy(v[i], src[i], len + 1);
+		i++;
 	}
-	if (len + 1 > cap)
-	{
-		nb = (char *)realloc(buf, len + 1);
-		if (nb == NULL)
-		{
-			free(buf);
-			return NULL;
-		}
-		buf = nb;
-	}
-	buf[len] = '\0';
-	return buf;
+	v[argc] = NULL;
+	return v;
 }
 
-/* ===== 1ケース実行 ===== */
-static void run_case(const char *title, const char *delim, t_quote_type q,
-                     const char **lines, size_t nlines)
+
+static void cmd_init(t_cmd *c, char **argv, int argc)
+{
+	c->argv = argv;
+	c->argc = argc;
+	c->redirs = NULL;
+	c->n_redirs = 0;
+}
+
+
+static void run_case(const char *title, const char *const *argv_lit, int argc_in)
 {
 	t_cmd c;
-	t_token *delim_tok;
 	int rc;
-	char *got;
-	int fd;
+	char **argv_heap = dup_argv_heap(argv_lit, argc_in);
 
-	printf("== %s ==\n", title);
-
-	/* 入力（readlineスタブ用） */
-	g_lines = lines;
-	g_nlines = nlines;
-	g_idx = 0;
-
-	delim_tok = new_arg_token_one_part(delim, q);
-	if (delim_tok == NULL)
+	printf("\n== %s ==\n", title);
+	if (!argv_heap)
 	{
-		printf("alloc error\n\n");
+		perror("dup_argv_heap");
 		return;
 	}
-	memset(&c, 0, sizeof(c));
-	cmd_init_1_heredoc(&c, delim_tok, q);
+	cmd_init(&c, argv_heap, argc_in);
 
-	rc = collect_heredocs(&c);
+	rc = glob_expand_argv(&c);
 	printf("rc=%d\n", rc);
-	if (rc == 0)
-	{
-		fd = c.redirs[0].fd;
-		printf("fd=%d (>=0ならOK)\n", fd);
-		if (fd >= 0)
-		{
-			/* 一時ファイル実装に備えて先頭へ、パイプなら ESPIPE→無視 */
-			(void)lseek(fd, 0, SEEK_SET);
+	print_argv(&c);
 
-			got = read_all_from_fd(fd);
-			if (got != NULL)
-			{
-				printf("content:\n---\n%s---\n", got);
-				free(got);
-			}
-			else
-			{
-				printf("content: (read error)\n");
-			}
-		}
-	}
-	else
-	{
-		printf("collect_heredocs failed\n");
-	}
-
-	cmd_destroy(&c);
-	printf("\n");
 }
 
 int main(void)
 {
-	/* Case1: 非引用: 展開あり実装なら展開対象 */
-	const char *lines1[] = { "hello", "world", "EOF" };
+	char cwd[1024];
 
-	/* Case2: 単一引用: 展開しない実装が多い */
-	const char *lines2[] = { "$USER", "EOF" };
+	if (setup_fs() != 0)
+	{
+		perror("setup_fs");
+		return 1;
+	}
+	if (!getcwd(cwd, sizeof(cwd)))
+		return 1;
+	if (chdir("_globtest") != 0)
+	{
+		perror("chdir");
+		return 1;
+	}
 
+	/* Case 1: 基本（*.txt が複数に展開） */
+	const char *case1[] = { "echo", "*.txt", NULL };
+	run_case("basic: *.txt expands to multiple", case1, 2);
 
-	run_case("heredoc: unquoted delimiter (<< EOF)",
-	         "EOF", Q_NONE,
-	         lines1, sizeof(lines1) / sizeof(lines1[0]));
+	/* Case 2: 混在（リテラル + グロブ + リテラル） */
+	const char *case2[] = { "cat", "a*.c", "Makefile", NULL };
+	run_case("mixed: a*.c expands, others stay", case2, 3);
 
-	run_case("heredoc: single-quoted delimiter (<< 'EOF')",
-	         "EOF", Q_SINGLE,
-	         lines2, sizeof(lines2) / sizeof(lines2[0]));
+	/* Case 3: マッチ0件（そのまま残す想定） */
+	const char *case3[] = { "echo", "zzz*.dat", NULL };
+	run_case("no match: keep literal", case3, 2);
 
+	/* Case 4: スラッシュ含み → 展開しない（should_glob_expand が弾く想定） */
+	const char *case4[] = { "echo", "dir/*", NULL };
+	run_case("has slash: do not expand", case4, 2);
+
+	/* Case 5: 複数スター（a*.*） */
+	const char *case5[] = { "echo", "a*.*", NULL };
+	run_case("multi-star pattern", case5, 2);
+
+	/* 戻す（_globtest はそのまま残す） */
+	(void)chdir(cwd);
 	return 0;
 }
 


### PR DESCRIPTION
glob_expand_argv(t_cmd *c) を実装。
argv 内のワイルドカード（*）を展開し、マッチするファイル名リストに置き換える。

bash に準拠して動作：
* はカレントディレクトリのファイルに展開。
/ を含むパターンは展開しない（リテラル維持）
マッチが 0 件の場合もリテラル維持（bash の nullglob 無効時と同じ）
展開結果は辞書順（readdir → sort）で格納
引数配列 c->argv を再確保し、展開後の argv / argc に更新する。
