### PR TITLE
Fix/7 heredocの修正

### DIFF
--- a/includes/exec.h
+++ b/includes/exec.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nnishiya <nnishiya@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/23 22:20:02 by tkuwahat          #+#    #+#             */
-/*   Updated: 2025/10/11 10:32:56 by nnishiya         ###   ########.fr       */
+/*   Updated: 2025/10/12 14:58:57 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,6 +100,7 @@ typedef enum e_pipe_role
 }							t_pipe_role;
 
 /* ast_exec / ast_destroy */
+int 						ast_execute_root(t_node *root, t_exec_ctx *ctx);
 int							ast_exec(t_node *node, t_exec_ctx *ctx);
 void						ast_destroy(t_node *node);
 /* exec / destroy */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/12 17:12:13 by nnishiya          #+#    #+#             */
-/*   Updated: 2025/10/12 13:31:09 by tkuwahat         ###   ########.fr       */
+/*   Updated: 2025/10/12 15:00:30 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,6 +119,7 @@ int								hdoc_write_line(int fd, const char *s);
 int								hdoc_open_pipe(int pfd[2]);
 
 int								collect_heredocs(t_cmd *c);
+int								collect_heredocs_for_tree(t_node *n);
 
 /*glob*/
 int								glob_expand_argv(t_cmd *c);

--- a/src/exec/exec_ast.c
+++ b/src/exec/exec_ast.c
@@ -6,11 +6,35 @@
 /*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/22 18:39:49 by tkuwahat          #+#    #+#             */
-/*   Updated: 2025/09/29 14:30:48 by tkuwahat         ###   ########.fr       */
+/*   Updated: 2025/10/12 15:13:30 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+int	handle_heredoc_error(int rc)
+{
+	if (rc == -2)
+	{
+		(void)write(STDOUT_FILENO, "\n", 1);
+		set_exit_status(130);
+		return (0);
+	}
+	set_exit_status(1);
+	return (-1);
+}
+
+int	ast_execute_root(t_node *root, t_exec_ctx *ctx)
+{
+	int	rc;
+
+	if (!root)
+		return (0);
+	rc = collect_heredocs_for_tree(root);
+	if (rc != 0)
+		return (handle_heredoc_error(rc));
+	return (ast_exec(root, ctx));
+}
 
 int	ast_exec(t_node *node, t_exec_ctx *ctx)
 {

--- a/src/exec/exec_cmd/exec_cmd.c
+++ b/src/exec/exec_cmd/exec_cmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_cmd.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nnishiya <nnishiya@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/23 22:09:18 by tkuwahat          #+#    #+#             */
-/*   Updated: 2025/10/11 10:43:03 by nnishiya         ###   ########.fr       */
+/*   Updated: 2025/10/12 15:13:13 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,21 +17,7 @@ int	prepare_cmd_for_exec(t_cmd *c)
 	int	rc;
 
 	if (!c)
-	{
-		set_exit_status(2);
-		return (-1);
-	}
-	rc = collect_heredocs(c);
-	if (rc != 0)
-	{
-		if (rc == -2)
-		{
-			(void)write(STDOUT_FILENO, "\n", 1);
-			set_exit_status(130);
-			return (end_with_error(c, 130));
-		}
-		return (set_exit_status(1), end_with_error(c, 1));
-	}
+		return (set_exit_status(2), -1);
 	rc = expansion(c);
 	if (rc != 0)
 		return (end_with_error(c, -1));

--- a/src/exec/exec_cmd/parent/exec_cmd_parent_main.c
+++ b/src/exec/exec_cmd/parent/exec_cmd_parent_main.c
@@ -6,7 +6,7 @@
 /*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/30 22:31:24 by tkuwahat          #+#    #+#             */
-/*   Updated: 2025/10/12 12:42:46 by tkuwahat         ###   ########.fr       */
+/*   Updated: 2025/10/12 15:13:06 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,6 @@ int	run_builtin_parent(t_cmd *c)
 	}
 	return (-1);
 }
-
 
 int	wait_child_status(pid_t pid, int *out_st)
 {

--- a/src/exec/exec_pipe/exec_pipe_call_child.c
+++ b/src/exec/exec_pipe/exec_pipe_call_child.c
@@ -6,7 +6,7 @@
 /*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/02 14:30:08 by tkuwahat          #+#    #+#             */
-/*   Updated: 2025/10/12 13:21:57 by tkuwahat         ###   ########.fr       */
+/*   Updated: 2025/10/12 15:12:36 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,8 +43,8 @@ static int	handle_right_spawn_fail(int fds[2], pid_t lp,
 static int	wait_both_and_take_right(pid_t lp, pid_t rp, int *st_right)
 {
 	int	stl;
-	int str;
-	int sigint_seen;
+	int	str;
+	int	sigint_seen;
 
 	stl = 0;
 	str = 0;
@@ -53,11 +53,12 @@ static int	wait_both_and_take_right(pid_t lp, pid_t rp, int *st_right)
 		return (-1);
 	if (waitpid_retry(rp, &str) < 0)
 		return (-1);
-	if ((WIFSIGNALED(stl) && WTERMSIG(stl) == SIGINT)|| (WIFSIGNALED(str) && WTERMSIG(str) == SIGINT))
+	if ((WIFSIGNALED(stl) && WTERMSIG(stl) == SIGINT) || (WIFSIGNALED(str)
+			&& WTERMSIG(str) == SIGINT))
 		sigint_seen = 1;
 	if (st_right)
 		*st_right = str;
-	return sigint_seen;
+	return (sigint_seen);
 }
 
 int	call_pipe_children(t_node *node, t_exec_ctx *parent_ctx, int fds[2],

--- a/src/exec/exec_pipe/exec_pipe_main.c
+++ b/src/exec/exec_pipe/exec_pipe_main.c
@@ -6,7 +6,7 @@
 /*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/02 14:30:08 by tkuwahat          #+#    #+#             */
-/*   Updated: 2025/10/12 13:05:20 by tkuwahat         ###   ########.fr       */
+/*   Updated: 2025/10/12 15:12:48 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,11 +17,33 @@ void	parent_unmask_sigint(struct sigaction *old)
 	(void)sigaction(SIGINT, old, NULL);
 }
 
+int	collect_heredocs_for_tree(t_node *n)
+{
+	int	rc;
+
+	if (!n)
+		return (0);
+	if (n->type == ND_COMMAND)
+		return (collect_heredocs(&n->u_as.cmd));
+	if (n->type == ND_PIPE)
+	{
+		rc = collect_heredocs_for_tree(n->u_as.s_bin.left);
+		if (rc != 0)
+			return (rc);
+		rc = collect_heredocs_for_tree(n->u_as.s_bin.right);
+		if (rc != 0)
+			return (rc);
+	}
+	if (n->type == ND_SUBSHELL)
+		return (collect_heredocs_for_tree(n->u_as.s_subshell.body));
+	return (0);
+}
+
 int	exec_pipe(t_node *node, t_exec_ctx *parent_ctx)
 {
 	int	fds[2];
 	int	st_right;
-	int rc;
+	int	rc;
 
 	if (!node || !node->u_as.s_bin.left || !node->u_as.s_bin.right)
 		return (set_exit_status(2), -1);
@@ -30,7 +52,7 @@ int	exec_pipe(t_node *node, t_exec_ctx *parent_ctx)
 	rc = call_pipe_children(node, parent_ctx, fds, &st_right);
 	if (rc < 0)
 		return (-1);
-	if (rc == 1) 
+	if (rc == 1)
 		set_exit_status(130);
 	else
 		set_exit_status(status_to_exitcode(st_right));

--- a/src/input/repl.c
+++ b/src/input/repl.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   repl.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nnishiya <nnishiya@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: tkuwahat <tkuwahat@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/12 15:40:21 by nnishiya          #+#    #+#             */
-/*   Updated: 2025/10/11 09:35:04 by nnishiya         ###   ########.fr       */
+/*   Updated: 2025/10/12 14:59:01 by tkuwahat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ static int	execute_command(t_exec_ctx *ctx)
 {
 	int	rc;
 
-	rc = ast_exec(get_ast(), ctx);
+	rc = ast_execute_root(get_ast(), ctx);
 	return (rc);
 }
 


### PR DESCRIPTION
親プロセスが複数の << を順に読み取り、それぞれの入力内容を個別のFDとして保存する。
その後、各コマンドの子プロセスで対応するFDを STDIN_FILENO にdupして実行に渡す方式へ。